### PR TITLE
Update footer.html with accessibility statement

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,6 +7,7 @@
                 <li><a href="https://www.ucar.edu/cookie-other-tracking-technologies-notice">Cookies</a></li>
                 <li><a href="https://www.ucar.edu/terms-of-use">Terms of Use</a></li>
                 <li><a href="https://www.ucar.edu/notification-copyright-infringement-digital-millenium-copyright-act">Copyright Issues</a></li>
+                <li><a href="https://www.ucar.edu/accessibility">Accessibility</a></li>
                 <li><a href="https://nsf.gov">Sponsored by NSF</a></li>
                 <li><a href="https://ncar.ucar.edu">NCAR Home</a></li>
                 <li><a href="https://www.ucar.edu">UCAR Home</a></li>


### PR DESCRIPTION
Per this [post on Sundog](https://sundog.ucar.edu/page/8090) all UCAR sites must have a link to the accessibility statement in the footer by Feb 1. The GeoCAT site uses this theme and this PR should add the statement to all sites using the theme.